### PR TITLE
Update localization.lua and fix the language select function

### DIFF
--- a/mods/base/loc/cht.txt
+++ b/mods/base/loc/cht.txt
@@ -85,7 +85,7 @@
 
 	"base_language_select" : "語言",
 	"base_language_select_desc" : "選擇 BLT 顯示的語言",
-	"base_language_en" : "英語",
+	"base_language_en" : "英語 English",
 	"base_language_de" : "德語",
 	"base_language_fr" : "法語",
 	"base_language_ru" : "俄語",

--- a/mods/base/req/localization.lua
+++ b/mods/base/req/localization.lua
@@ -10,7 +10,6 @@ function LuaModManager:LoadAvailableLanguages()
 
 	-- Add all localisation files
 	local loc_files = file.GetFiles( LuaModManager.Constants.localisation_folder )
-	loc_files = false
 	if type(loc_files) ~= "table" then
 		loc_files = {
 			"en.txt"


### PR DESCRIPTION
removed loc_files = false, so the type of loc_files is able to keep "table" if the loc directory contain different languages.
So it restore the function of changing language of BLT in game option.(if keeping loc_files = false, the only choice is English.)

also update cht.txt for someone switch to chinese wrongly and able to switch back to english without font (if they can remember how to access the option of BLT :D )