### PR TITLE
fix menu id's & fail-safe for old saves file conversion

### DIFF
--- a/mods/base/req/BLTModManager.lua
+++ b/mods/base/req/BLTModManager.lua
@@ -283,8 +283,8 @@ BLTModManager.Constants.mod_path_global = "ModPath"
 BLTModManager.Constants.logs_path_global = "LogsPath"
 BLTModManager.Constants.save_path_global = "SavePath"
 
-BLTModManager.Constants.lua_mods_menu_id = "base_lua_mods_menu"
-BLTModManager.Constants.lua_mod_options_menu_id = "lua_mod_options_menu"
+BLTModManager.Constants.lua_mods_menu_id = "blt_mods_new"
+BLTModManager.Constants.lua_mod_options_menu_id = "blt_options"
 
 function BLTModManager.Constants:ModsDirectory()
 	return self["mods_directory"]

--- a/mods/base/req/BLTModManager.lua
+++ b/mods/base/req/BLTModManager.lua
@@ -202,7 +202,15 @@ function BLTModManager:ConvertOldSaveFiles()
 
 	-- Load old files
 	local enabled_mods = io.load_as_json( BLTModManager.Constants:OldModManagerSaveFile() )
+	if enabled_mods == nil or type(enabled_mods) ~= "table" then
+		enabled_mods = {}
+	end
+	--[[ TODO
 	local keybinds_data = io.load_as_json( BLTModManager.Constants:OldModManagerKeybindsFile() )
+	if keybinds_data == nil or type(keybinds_data) ~= "table" then
+		keybinds_data = {}
+	end
+	]]
 
 	-- Convert enabled mods data
 	for mod_id, enabled in pairs( enabled_mods ) do


### PR DESCRIPTION
- some mods are using the Constants table to attach their menu, which would fail with the old identifiers, so let's give them the new ones.

- The fail-safe is for empty/missing/faulty "mod_mananger.txt" files (this should fix the bug xtakku reported here:  https://github.com/JamesWilko/Payday-2-BLT/issues/86)
- commented the keybinds_data section out, since its not used for now anyways.