### PR TITLE
Options menu items of type "keybind" can be defined in JSON menus.

### DIFF
--- a/mods/base/req/BLTKeybindsManager.lua
+++ b/mods/base/req/BLTKeybindsManager.lua
@@ -333,7 +333,8 @@ function BLTKeybindMenuInitiator:modify_node( node )
 
 			-- Seperate keybinds by mod
 			if last_mod and last_mod ~= bind:ParentMod() then
-				self:create_divider( node, tostring(i) )
+				self:create_divider( node, tostring(i), nil, 16 )
+				self:create_divider( node, tostring(i) .. '_modname', bind:ParentMod():GetName(), nil, Color.white, false )
 			end
 			last_mod = bind:ParentMod()
 
@@ -377,7 +378,7 @@ function BLTKeybindMenuInitiator:create_item( node, params )
 	node:add_item( new_item )
 end
 
-function BLTKeybindMenuInitiator:create_divider( node, id, text_id, size, color )
+function BLTKeybindMenuInitiator:create_divider( node, id, text_id, size, color, localize )
 
 	local params = {
 		name = "divider_" .. id,
@@ -385,8 +386,9 @@ function BLTKeybindMenuInitiator:create_divider( node, id, text_id, size, color 
 		text_id = text_id,
 		size    = size or 8,
 		color   = color,
+		localize = localize
 	}
-	
+
 	local data_node = { type = "MenuItemDivider" }
 	local new_item = node:create_item( data_node, params )
 	node:add_item( new_item )

--- a/mods/base/req/BLTKeybindsManager.lua
+++ b/mods/base/req/BLTKeybindsManager.lua
@@ -232,8 +232,8 @@ function BLTKeybindsManager:update( t, dt, state )
 		if bind:HasKey() and bind:CanExecuteInState( state ) then
 
 			local key = bind:Key()
-			if string.find(key, "mouse ") ~= nil then
-				key_pressed = self._input_mouse:pressed( key:sub(7) )
+			if string.find(key, "mouse ") == 1 then
+				key_pressed = self._input_mouse:pressed( Idstring(key:sub(7)) )
 			else
 				key_pressed = self._input_keyboard:pressed( Idstring(key) )
 			end

--- a/mods/base/req/BLTKeybindsManager.lua
+++ b/mods/base/req/BLTKeybindsManager.lua
@@ -332,9 +332,11 @@ function BLTKeybindMenuInitiator:modify_node( node )
 		if bind:ShowInMenu() then
 
 			-- Seperate keybinds by mod
-			if last_mod and last_mod ~= bind:ParentMod() then
-				self:create_divider( node, tostring(i), nil, 16 )
-				self:create_divider( node, tostring(i) .. '_modname', bind:ParentMod():GetName(), nil, Color.white, false )
+			if last_mod ~= bind:ParentMod() then
+				if last_mod then
+					self:create_divider( node, tostring(i) , nil, 16)
+				end
+				self:create_divider( node, tostring(i), bind:ParentMod():GetName(), nil, Color.white, false )
 			end
 			last_mod = bind:ParentMod()
 

--- a/mods/base/req/BLTModManager.lua
+++ b/mods/base/req/BLTModManager.lua
@@ -23,6 +23,14 @@ function BLTModManager:GetMod( id )
 	end
 end
 
+function BLTModManager:GetModOwnerOfFile( file )
+	for _, mod in pairs( self:Mods() ) do
+		if string.find( file, mod:GetPath() ) == 1 then
+			return mod
+		end
+	end
+end
+
 function BLTModManager:SetModsList( mods_list )
 
 	-- Set mods

--- a/mods/base/req/core/MenuHelper.lua
+++ b/mods/base/req/core/MenuHelper.lua
@@ -511,8 +511,23 @@ function MenuHelper:LoadFromJsonFile( file_path, parent_class, data_table )
 
 					local key = ""
 					if item.keybind_id then
-						-- key = LuaModManager:GetPlayerKeybind( item.keybind_id ) or ""
-						key = ""
+						local mod = BLT.Mods:GetModOwnerOfFile( file_path )
+						if mod then
+							local params = {
+								id = item.keybind_id,
+								allow_menu = item.run_in_menu,
+								allow_game = item.run_in_game,
+								show_in_menu = item.show_in_menu,
+								name = title,
+								desc = desc,
+								localize = true,
+								callback = item.func and MenuCallbackHandler[item.func],
+							}
+							BLT.Keybinds:register_keybind( mod, params )
+						end
+
+						local bind = BLT.Keybinds:get_keybind( item.keybind_id )
+						key = bind and bind:Key() or ""
 					end
 
 					MenuHelper:AddKeybinding({
@@ -526,8 +541,6 @@ function MenuHelper:LoadFromJsonFile( file_path, parent_class, data_table )
 						priority = priority,
 						localized = localized,
 					})
-
-					-- LuaModManager:AddKeybinding( item.keybind_id, parent_class[item.func] )
 
 				end
 


### PR DESCRIPTION
To take the existing example of Keepers, I define:

    {  
        "type" : "keybind",
        "id" : "kpr_keybind_follow",
        "title" : "kpr_keybind_follow_title",
        "description" : "kpr_keybind_follow_desc",
        "keybind_id" : "keepers_follow",
        "run_in_game" : true,
        "func" : "KeybindFollow"
    },

(func KeybindFollow points to MenuCallbackHandler.KeybindFollow)

The mod's options menu looks like: [http://i.imgur.com/4UfXmYQ.jpg](http://i.imgur.com/4UfXmYQ.jpg)
(see 2 keybinds in the bottom)

Mod keybinds manager's options menu looks like: [https://i.imgur.com/cFmdoAX.jpg](https://i.imgur.com/cFmdoAX.jpg)