### PR TITLE
Add _temp folder to excluded mod directories

### DIFF
--- a/mods/base/req/BLTModManager.lua
+++ b/mods/base/req/BLTModManager.lua
@@ -276,6 +276,7 @@ BLTModManager.Constants.ExcludedModDirectories = {
 	["logs"] = true,
 	["saves"] = true,
 	["downloads"] = true,
+	["_temp"] = true,
 }
 BLTModManager.Constants.required_script_global = "RequiredScript"
 BLTModManager.Constants.mod_path_global = "ModPath"


### PR DESCRIPTION
Currently BLT attempts to load the _temp folder as a mod which causes it to complain about a missing mod.txt file in the log, let's ignore the folder altogether.