### PR TITLE
Fix a crash related to missing dependencies

### DIFF
--- a/mods/base/req/BLTModDependency.lua
+++ b/mods/base/req/BLTModDependency.lua
@@ -85,3 +85,7 @@ end
 function BLTModDependency:ViewPatchNotes()
 	BLTUpdate.ViewPatchNotes( self )
 end
+
+function BLTModDependency:IsCritical()
+	return true
+end


### PR DESCRIPTION
Application has crashed: C++ exception
mods/base/req/ui/BLTUIControls.lua:313: attempt to call method 'IsCritical' (a nil value)

SCRIPT STACK

new() @mods/base/req/utils/UtilsClass.lua:26
_setup() @mods/base/req/ui/BLTDownloadManagerGui.lua:125
init() @mods/base/req/ui/BLTDownloadManagerGui.lua:34
new() @mods/base/req/utils/UtilsClass.lua:26
create() @mods/base/req/ui/BLTDownloadManagerGui.lua:257
set_active_components() lib/managers/menu/menucomponentmanager.lua:429
set_active_components() @mods/base/lua/MenuComponentManager.lua:19
core/lib/managers/menu/coremenulogic.lua:89
_execute_action_queue() core/lib/managers/menu/coremenulogic.lua:54
update() core/lib/managers/menu/coremenulogic.lua:64
update() core/lib/managers/menu/coremenumanager.lua:159
update() lib/managers/menumanagerpd2.lua:17
update() lib/setups/setup.lua:740
update() lib/setups/menusetup.lua:294
update() @mods/base/lua/MenuSetup.lua:6
core/lib/setups/coresetup.lua:537