### PR TITLE
fix downloading of "dependencies"

### DIFF
--- a/mods/base/req/BLTModDependency.lua
+++ b/mods/base/req/BLTModDependency.lua
@@ -85,3 +85,7 @@ end
 function BLTModDependency:ViewPatchNotes()
 	BLTUpdate.ViewPatchNotes( self )
 end
+
+function BLTModDependency:IsCritical()
+	return true
+end

--- a/mods/base/req/BLTModDependency.lua
+++ b/mods/base/req/BLTModDependency.lua
@@ -89,3 +89,11 @@ end
 function BLTModDependency:IsCritical()
 	return true
 end
+
+function BLTModDependency:GetInstallFolder()
+	return self._server_data.name
+end
+
+function BLTModDependency:GetServerHash()
+	return self._server_data.hash
+end


### PR DESCRIPTION
this includes https://github.com/JamesWilko/Payday-2-BLT-Lua/pull/36

This PR will fix the new "dependencies" node, which replaced "libraries" due to the BLT 2.0 rewrite.
missing dependencies will now appear in the updates list, instead of crashing the game and can be downloaded as intended.