### PR TITLE
fix back button priority

### DIFF
--- a/mods/base/req/ui/BLTDownloadManagerGui.lua
+++ b/mods/base/req/ui/BLTDownloadManagerGui.lua
@@ -212,10 +212,10 @@ function BLTDownloadManagerGui:mouse_moved( button, x, y )
 	end
 
 	for _, item in ipairs( self._buttons ) do
+		if item.mouse_moved then
+			item:mouse_moved( button, x, y )
+		end
 		if not used and item:inside( x, y ) then
-			if item.mouse_moved then
-				item:mouse_moved( button, x, y )
-			end
 			item:set_highlight( true )
 			used, pointer = true, "link"
 		else

--- a/mods/base/req/ui/BLTDownloadManagerGui.lua
+++ b/mods/base/req/ui/BLTDownloadManagerGui.lua
@@ -121,7 +121,7 @@ function BLTDownloadManagerGui:_setup()
 			w = self._scroll:canvas():w(),
 			h = h,
 			update = download.update,
-		} 
+		}
 		local button = BLTDownloadControl:new( self._scroll:canvas(), data )
 		table.insert( self._buttons, button )
 
@@ -169,6 +169,13 @@ end
 
 function BLTDownloadManagerGui:mouse_clicked( o, button, x, y )
 
+	if alive(self._back_button) and self._back_button:visible() then
+		if self._back_button:inside(x, y) then
+			managers.menu:back()
+			return true
+		end
+	end
+
 	for _, item in ipairs( self._buttons ) do
 		if item:inside( x, y ) then
 			if item:parameters().callback then
@@ -178,13 +185,6 @@ function BLTDownloadManagerGui:mouse_clicked( o, button, x, y )
 				item:mouse_clicked( button, x, y )
 			end
 			managers.menu_component:post_event( "menu_enter" )
-			return true
-		end
-	end
-
-	if alive(self._back_button) and self._back_button:visible() then
-		if self._back_button:inside(x, y) then
-			managers.menu:back()
 			return true
 		end
 	end
@@ -199,18 +199,6 @@ function BLTDownloadManagerGui:mouse_moved( button, x, y )
 
 	local used, pointer
 
-	for _, item in ipairs( self._buttons ) do
-		if item.mouse_moved then
-			item:mouse_moved( button, x, y )
-		end
-		if item:inside( x, y ) then
-			item:set_highlight( true )
-			used, pointer = true, "link"
-		else
-			item:set_highlight( false )
-		end
-	end
-
 	if alive(self._back_button) and self._back_button:visible() then
 		if self._back_button:inside(x, y) then
 			if self._back_button:color() ~= tweak_data.screen_colors.button_stage_2 then
@@ -220,6 +208,18 @@ function BLTDownloadManagerGui:mouse_moved( button, x, y )
 			used, pointer = true, "link"
 		else
 			self._back_button:set_color( tweak_data.screen_colors.button_stage_3 )
+		end
+	end
+
+	for _, item in ipairs( self._buttons ) do
+		if not used and item:inside( x, y ) then
+			if item.mouse_moved then
+				item:mouse_moved( button, x, y )
+			end
+			item:set_highlight( true )
+			used, pointer = true, "link"
+		else
+			item:set_highlight( false )
 		end
 	end
 

--- a/mods/base/req/ui/BLTModsGui.lua
+++ b/mods/base/req/ui/BLTModsGui.lua
@@ -162,16 +162,6 @@ function BLTModsGui:mouse_moved( button, x, y )
 
 	local used, pointer
 
-	local inside_scroll = alive(self._scroll) and self._scroll:panel():inside( x, y )
-	for _, item in ipairs( self._buttons ) do
-		if item:inside( x, y ) and inside_scroll then
-			item:set_highlight( true )
-			used, pointer = true, "link"
-		else
-			item:set_highlight( false )
-		end
-	end
-
 	if alive(self._back_button) and self._back_button:visible() then
 		if self._back_button:inside(x, y) then
 			if self._back_button:color() ~= tweak_data.screen_colors.button_stage_2 then
@@ -181,6 +171,16 @@ function BLTModsGui:mouse_moved( button, x, y )
 			used, pointer = true, "link"
 		else
 			self._back_button:set_color( tweak_data.screen_colors.button_stage_3 )
+		end
+	end
+
+	local inside_scroll = alive(self._scroll) and self._scroll:panel():inside( x, y )
+	for _, item in ipairs( self._buttons ) do
+		if not used and item:inside( x, y ) and inside_scroll then
+			item:set_highlight( true )
+			used, pointer = true, "link"
+		else
+			item:set_highlight( false )
 		end
 	end
 
@@ -205,9 +205,16 @@ function BLTModsGui:mouse_clicked( o, button, x, y )
 end
 
 function BLTModsGui:mouse_pressed( button, x, y )
-	
+
 	if managers.menu_scene and managers.menu_scene:input_focus() then
 		return false
+	end
+
+	if alive(self._back_button) and self._back_button:visible() then
+		if self._back_button:inside(x, y) then
+			managers.menu:back()
+			return true
+		end
 	end
 
 	if alive(self._scroll) and self._scroll:panel():inside( x, y ) then
@@ -232,13 +239,6 @@ function BLTModsGui:mouse_pressed( button, x, y )
 
 	end
 
-	if alive(self._back_button) and self._back_button:visible() then
-		if self._back_button:inside(x, y) then
-			managers.menu:back()
-			return true
-		end
-	end
-
 	if alive(self._scroll) then
 		return self._scroll:mouse_pressed( button, x, y )
 	end
@@ -246,7 +246,7 @@ function BLTModsGui:mouse_pressed( button, x, y )
 end
 
 function BLTModsGui:mouse_released( button, x, y )
-	
+
 	if managers.menu_scene and managers.menu_scene:input_focus() then
 		return false
 	end

--- a/mods/base/req/ui/BLTViewModGui.lua
+++ b/mods/base/req/ui/BLTViewModGui.lua
@@ -409,19 +409,19 @@ end
 
 function BLTViewModGui:mouse_clicked( o, button, x, y )
 
+	if alive(self._back_button) and self._back_button:visible() then
+		if self._back_button:inside(x, y) then
+			managers.menu:back()
+			return true
+		end
+	end
+
 	for _, item in ipairs( self._buttons ) do
 		if item:inside( x, y ) then
 			if item:parameters().callback then
 				item:parameters().callback()
 			end
 			managers.menu_component:post_event( "menu_enter" )
-			return true
-		end
-	end
-
-	if alive(self._back_button) and self._back_button:visible() then
-		if self._back_button:inside(x, y) then
-			managers.menu:back()
 			return true
 		end
 	end
@@ -436,15 +436,6 @@ function BLTViewModGui:mouse_moved( button, x, y )
 
 	local used, pointer
 
-	for _, item in ipairs( self._buttons ) do
-		if item:inside( x, y ) then
-			item:set_highlight( true )
-			used, pointer = true, "link"
-		else
-			item:set_highlight( false )
-		end
-	end
-
 	if alive(self._back_button) and self._back_button:visible() then
 		if self._back_button:inside(x, y) then
 			if self._back_button:color() ~= tweak_data.screen_colors.button_stage_2 then
@@ -454,6 +445,15 @@ function BLTViewModGui:mouse_moved( button, x, y )
 			used, pointer = true, "link"
 		else
 			self._back_button:set_color( tweak_data.screen_colors.button_stage_3 )
+		end
+	end
+
+	for _, item in ipairs( self._buttons ) do
+		if not used and item:inside( x, y ) then
+			item:set_highlight( true )
+			used, pointer = true, "link"
+		else
+			item:set_highlight( false )
 		end
 	end
 
@@ -551,7 +551,7 @@ function BLTViewModGui:clbk_check_for_updates_finished( cache )
 		managers.system_menu:show( dialog_data )
 
 	else
-		
+
 		local dialog_data = {}
 		dialog_data.title = managers.localization:text( "blt_update_mod_title", { name = self._mod:GetName() } )
 		dialog_data.text = managers.localization:text( "blt_update_mod_available", { name = self._mod:GetName() } )


### PR DESCRIPTION
this fixes tiles being highlighted and clickable while being behind a back button.
actually the 2 buttons of BLTDownloadControl are still getting highlighted, but atleast the click wont be passed anymore.