### PR TITLE
Check mod id for dependencies

### DIFF
--- a/mods/base/req/BLTMod.lua
+++ b/mods/base/req/BLTMod.lua
@@ -416,10 +416,14 @@ function BLTMod:AreDependenciesInstalled()
 
 		local found = false
 		for _, mod in ipairs( BLT.Mods:Mods() ) do
-			for _, update in ipairs( mod:GetUpdates() ) do
-				if update:GetId() == id then
-					found = true
-					break
+			if mod:GetId() == id then
+				found = true
+			else
+				for _, update in ipairs( mod:GetUpdates() ) do
+					if update:GetId() == id then
+						found = true
+						break
+					end
 				end
 			end
 			if found then


### PR DESCRIPTION
Mods like BeardLib no longer use paydaymods updating method and because of that mods that define BeardLib in their dependencies still get an alert that the dependency is not installed, so to solve it we can simply check the id of the mod.