### PR TITLE
add support for mod dependencies which are not blt-updated

### DIFF
--- a/mods/base/req/BLTModDependency.lua
+++ b/mods/base/req/BLTModDependency.lua
@@ -1,15 +1,20 @@
 
 BLTModDependency = BLTModDependency or blt_class()
 
-function BLTModDependency:init( parent_mod, id )
+function BLTModDependency:init( parent_mod, id, is_not_blt_updated )
 
 	self._id = id
 	self._parent_mod = parent_mod
+	self._is_blt_updated = not is_not_blt_updated or true
 
 end
 
 function BLTModDependency:GetId()
 	return self._id
+end
+
+function BLTModDependency:IsBLTUpdated()
+	return self._is_blt_updated
 end
 
 function BLTModDependency:GetParentMod()


### PR DESCRIPTION
the reason for this patch can be read here: https://github.com/JamesWilko/Payday-2-BLT-Lua/pull/48
with this solution a mod like beardlib could define
`

    ...
    "providing" : [ "beardlib" ],
    ...

`
... in it's mod.txt, without having to use the blt updater for itself, while mods that need beardlib would now define its dependency the following way:

`

    ...
    "dependencies": [
        {
            "identifier": "beardlib",
            "is_not_blt_updated": true
        }
    ],
    ...

`

the table structure of a dependency is optional, and simple strings still work, while is_not_blt_updated defaults to false!
of course it would also work without the is_not_blt_updated flag, the blt update server would just not return any result, but i don't see why to spam more requests as needed.

you can also define mixed dependency formats, like this:

`

    ...
    "dependencies": [
        "delayedcallsfix",
        {
            "identifier": "beardlib",
            "is_not_blt_updated": true
        }
    ],
    ...

`
