### PR TITLE
Linux support (DB:create_entry)

### DIFF
--- a/mods/base/req/BLTMod.lua
+++ b/mods/base/req/BLTMod.lua
@@ -275,6 +275,11 @@ function BLTMod:GetModImage()
 		return nil
 	end
 
+	-- BLT4L doesn't currently have DB support
+	if not DB or not DB.create_entry then
+		return nil
+	end
+
 	-- Check if the file exists on disk and generate if it does
 	if SystemFS:exists( Application:nice_path( self:GetModImagePath(), true ) ) then
 		


### PR DESCRIPTION
On the Linux version of PAYDAY 2, the DB system is missing. This patch prevents icons from showing up if that is the case, fixing the mods menu on BLT4L.