### PR TITLE
Don't use static chat manager

### DIFF
--- a/mods/base/req/core/Networking.lua
+++ b/mods/base/req/core/Networking.lua
@@ -128,10 +128,11 @@ function LuaNetworking:SendToPeersExcept(peer, type_prm, data)
 end
 
 function LuaNetworking:SendStringThroughChat(message)
-	if ChatManager._receivers == nil then
-		ChatManager._receivers = {}
+	local chat_manager = managers.chat
+	if chat_manager._receivers == nil then
+		chat_manager._receivers = {}
 	end
-	ChatManager:send_message( LuaNetworking.HiddenChannel, tostring(LuaNetworking:LocalPeerID()), message )
+	chat_manager:send_message( LuaNetworking.HiddenChannel, tostring(LuaNetworking:LocalPeerID()), message )
 end
 
 Hooks:Add("ChatManagerOnReceiveMessage", "ChatManagerOnReceiveMessage_Network", function(channel_id, name, message, color, icon)


### PR DESCRIPTION
It doesn't have stuff like _muted_peers initialized and cause crashes.