### PR TITLE
Add: Japanese localization

### DIFF
--- a/mods/base/loc/ja.txt
+++ b/mods/base/loc/ja.txt
@@ -1,0 +1,97 @@
+{
+	"blt_options_menu_blt_mods" : "BLT Mods",
+	"blt_options_menu_blt_mods_desc" : "インストールされているBLT modの更新や管理を行う",
+	"blt_options_menu_lua_mod_options" : "Mod 設定",
+	"blt_options_menu_lua_mod_options_desc" : "インストールされているBLT modの設定やカスタマイズを行う",
+	"blt_options_menu_keybinds" : "Mod キー割り当て",
+	"blt_options_menu_keybinds_desc" : "BLT modのキー割り当てを設定する",
+
+	"blt_mod_outdated" : "このmodは古いBLT用でサポートされていません; このmodの開発者は最新版のBLTをサポートするよう更新してください。 このmodをインストールしたままにしているとエラーやクラッシュが発生します。",
+	"blt_mod_missing_dependencies" : "このmodを動作させるにはインストールされていない他のmodが必要です。 このmodは無効化されました。",
+	"blt_mod_missing_dependency" : "    前提不足: $dependency",
+	"blt_mod_missing_dependency_download" : "    前提不足: $dependency をダウンロードマネージャーに追加しました。",
+	"blt_mod_dependency_disabled" : "このmodを動作させるには有効化されていない他のmodが必要です。 このmodは無効化されました。",
+	"blt_mod_disabled_dependency" : "    無効中: $dependency",
+
+	"blt_mod_info_author" : "作者",
+	"blt_mod_info_contact" : "連絡先",
+
+	"blt_mod_state_enabled" : "有効",
+	"blt_mod_state_enabled_desc" : "このmodはゲームの開始時に読み込まれます。",
+	"blt_mod_state_disabled" : "無効",
+	"blt_mod_state_disabled_desc" : "このmodはゲームが開始されても読み込まれません。",
+	"blt_mod_state_forced_disabled" : "無効",
+	"blt_mod_state_forced_disabled_desc" : "このmodは古いバージョンの為、読み込むことが出来ませんでした。",
+
+	"blt_mod_state_enabled_on_restart" : "再起動後に有効化",
+	"blt_mod_state_enabled_on_restart_desc" : "このmodは次回のゲーム開始時に読み込まれます。",
+	"blt_mod_state_disabled_on_restart" : "再起動後に無効化",
+	"blt_mod_state_disabled_on_restart_desc" : "このmodは次回のゲーム開始時から読み込まれなくなります。",
+
+	"blt_mod_safemode_enabled" : "セーフモード:\n有効",
+	"blt_mod_safemode_enabled_help" : "ゲームの主要な更新があった後のクラッシュを防ぐため自動的に無効化します。",
+	"blt_mod_safemode_disabled" : "セーフモード:\n無効",
+	"blt_mod_safemode_disabled_help" : "ゲームの主要な更新があった後でも自動的に無効化されません。",
+
+	"blt_mod_updates_enabled" : "自動更新:\n有効",
+	"blt_mod_updates_enabled_help" : "自動的にPaydayModsサーバーへmodの更新確認を行います。",
+	"blt_mod_updates_disabled" : "自動更新:\n無効",
+	"blt_mod_updates_disabled_help" : "PaydayModsサーバーへmodの更新確認は行われません。",
+
+	"blt_mod_check_for_updates" : "更新を確認する",
+	"blt_mod_check_for_updates_desc" : "今すぐPaydayMods サーバーに更新を問い合わせます。",
+
+	"blt_mod_toggle_dev" : "開発者向け情報を切り替える",
+	"blt_mod_toggle_dev_desc" : "このmodの開発者向け情報を表示/非表示します。",
+
+	"blt_update_mod_title" : "$name の更新",
+	"blt_update_mod_up_to_date" : "$name は既に最新版です。",
+	"blt_update_mod_error" : "Modが最新版であるかの確認が出来ませんでした。\n$reason",
+	"blt_update_mod_available" : "$name の更新が利用可能です！ダウンロードマネージャーに追加しました！",
+	"blt_update_mod_goto_manager" : "ダウンロードマネージャーを開く",
+
+	"blt_update_dll_title" : "重要な更新",
+	"blt_update_dll_text" : "BLT Dllの更新が利用可能です。ウェブサイトからダウンロードし直し、手動で更新をインストールする必要があります。\n\n可能な限り早く更新してください。これはゲームのクラッシュを修正する重要な更新です。",
+	"blt_update_dll_goto_website" : "PaydayMods のダウンロードページを開く",
+	"blt_update_later" : "後で更新する",
+
+	"blt_download_manager" : "ダウンロードマネージャー",
+	"blt_download_manager_help" : "BLT modを更新しましょう。\nFor the love of god update your mods.",
+	"blt_download_ready" : "ダウンロードの準備が出来ました。",
+	"blt_download_waiting" : "待機中...",
+	"blt_download_downloading" : "ダウンロード中... $bytes;b/$total_bytes;b",
+	"blt_download_saving" : "ディスクに保存中...",
+	"blt_download_extracting" : "展開中...",
+	"blt_download_verifying" : "検証中...",
+	"blt_download_failed" : "失敗！ 再試行しますか？",
+	"blt_download_done" : "完了！",
+	"blt_download_dependency" : "$dependency, $mod の前提要求",
+	"blt_download_all" : "全て更新",
+
+	"blt_checking_updates" : "更新を確認中です",
+	"blt_checking_updates_help" : "PaydayMods サーバーにmodの更新を確認中です、しばらくお待ち下さい...",
+	"blt_checking_updates_required" : "更新が必要です",
+	"blt_checking_updates_required_help" : "Modの更新が利用可能です。ダウンロードマネージャーから更新してください！",
+	"blt_view_patch_notes" : "更新履歴を見る",
+	"blt_checking_updates_none_required" : "ご利用のmodは全て最新版です！",
+	"blt_checking_updates_none_required_help" : "どのmodも更新する必要はありません！",
+
+	"blt_language_select" : "言語",
+	"blt_language_select_desc" : "BLTの表示に使用する言語を選択してください",
+	"blt_language_en" : "英語",
+	"blt_language_es" : "スペイン語",
+	"blt_language_cht" : "中国語 (繁体)",
+	"blt_language_de" : "ドイツ語",
+	"blt_language_fr" : "フランス語",
+	"blt_language_ru" : "ロシア語",
+	"blt_language_tr" : "トルコ語",
+	"blt_language_id" : "インドネシア語",
+	"blt_language_it" : "イタリア語",
+	"blt_language_zh-cn" : "中国語",
+	"blt_language_ja" : "日本語",
+
+	"blt_no_image" : "画像無し",
+	"blt_no_name" : "名前無し",
+	"blt_no_desc" : "説明無し"
+
+}


### PR DESCRIPTION
I localized `en.txt` to Japanese.
If there is Japanese contributer, I prefer check of my sentences from you.

Also, should I add `"blt_language_ja" : "日本語"` this line to all of other lang files?
I didn't editing them because some of file has different json format.
 