### PR TITLE
Make Utils:GetCrosshairRay() always use camera's data

### DIFF
--- a/mods/base/req/utils/UtilsCore.lua
+++ b/mods/base/req/utils/UtilsCore.lua
@@ -279,20 +279,20 @@ end
 ]]
 function Utils:GetCrosshairRay( from, to, slot_mask )
 
+	local viewport = managers.viewport
+	if not viewport:get_current_camera() then
+		return false
+	end
+
 	slot_mask = slot_mask or "bullet_impact_targets"
 
 	if not from then
-		local player = managers.player:player_unit()
-		if player then
-			from = player:movement():m_head_pos()
-		else
-			from = managers.viewport:get_current_camera_position()
-		end
+		from = viewport:get_current_camera_position()
 	end
 
 	if not to then
 		to = Vector3()
-		mvector3.set( to, player:camera():forward() )
+		mvector3.set( to, viewport:get_current_camera_rotation():y() )
 		mvector3.multiply( to, 20000 )
 		mvector3.add( to, from )
 	end


### PR DESCRIPTION
- Ray is valid even if the player is using a camera asset.
- In "if not to then" block, there was an uninitialized variable "player" so not providing a to parameter would crash.