### PR TITLE
Added GetModByName function to BLTModManager

### DIFF
--- a/mods/base/req/BLTModManager.lua
+++ b/mods/base/req/BLTModManager.lua
@@ -23,6 +23,14 @@ function BLTModManager:GetMod( id )
 	end
 end
 
+function BLTModManager:GetModByName(name)
+	for _, mod in pairs( self:Mods() ) do
+		if mod:GetName() == name then
+			return mod
+		end
+	end
+end
+
 function BLTModManager:GetModOwnerOfFile( file )
 	for _, mod in pairs( self:Mods() ) do
 		if string.find( file, mod:GetPath() ) == 1 then


### PR DESCRIPTION
I don't like checking for folder name(what GetMod does) for mods, they can be different sometimes(like times where the mod.txt is in the root of a github repo and the folder name is the repo name + branch instead)