### PR TITLE
Fix mod updating process in case of failure

### DIFF
--- a/mods/base/req/BLTDownloadManager.lua
+++ b/mods/base/req/BLTDownloadManager.lua
@@ -181,7 +181,20 @@ function BLTDownloadManager:clbk_download_finished( data, http_id )
 		-- Remove old installation
 		log("[Downloads] Removing old installation...")
 		wait()
-		SystemFS:delete_file( install_path )
+		local old_install_path = install_path .. '_old'
+		if not file.MoveDirectory( install_path, old_install_path ) then
+			log("[Downloads] Failed to rename old installation!")
+			download.state = "failed"
+			cleanup()
+			return
+		end
+
+		if not SystemFS:delete_file( old_install_path ) then
+			log("[Downloads] Failed to delete old installation!")
+			download.state = "failed"
+			cleanup()
+			return
+		end
 
 		-- Move the temporary installation
 		local move_success = file.MoveDirectory( extract_path, install_path )

--- a/mods/base/req/BLTDownloadManager.lua
+++ b/mods/base/req/BLTDownloadManager.lua
@@ -179,21 +179,23 @@ function BLTDownloadManager:clbk_download_finished( data, http_id )
 		end
 
 		-- Remove old installation
-		log("[Downloads] Removing old installation...")
 		wait()
-		local old_install_path = install_path .. '_old'
-		if not file.MoveDirectory( install_path, old_install_path ) then
-			log("[Downloads] Failed to rename old installation!")
-			download.state = "failed"
-			cleanup()
-			return
-		end
+		if SystemFS:exists(install_path) then
+			local old_install_path = install_path .. '_old'
+			log("[Downloads] Removing old installation...")
+			if not file.MoveDirectory( install_path, old_install_path ) then
+				log("[Downloads] Failed to rename old installation!")
+				download.state = "failed"
+				cleanup()
+				return
+			end
 
-		if not SystemFS:delete_file( old_install_path ) then
-			log("[Downloads] Failed to delete old installation!")
-			download.state = "failed"
-			cleanup()
-			return
+			if not SystemFS:delete_file( old_install_path ) then
+				log("[Downloads] Failed to delete old installation!")
+				download.state = "failed"
+				cleanup()
+				return
+			end
 		end
 
 		-- Move the temporary installation


### PR DESCRIPTION
Problem:

02:23:34 PM Lua: [Downloads] Verifying...
02:23:34 PM Lua: [Downloads] Removing old installation...
02:23:34 PM Log:  (..\src\util\util.cpp:100) MoveFileEx failed with error 183
02:23:34 PM Lua: [Downloads] Complete!
02:23:42 PM Lua: [Downloads] Flushing complete downloads...

It seems to happen for multiple reasons and instead of updating a mod, said mod is just deleted and that's not what I call a happy ending.

Error 183 is a failed move because target already exists. So we just rename the old installation directory before deleting it, any handle still alive will disagree before attempting to delete any file. This has fixed all reproduceable failures I found.