### PR TITLE
Fix dependency check for long chains

### DIFF
--- a/mods/base/req/BLTMod.lua
+++ b/mods/base/req/BLTMod.lua
@@ -81,6 +81,7 @@ function BLTMod:Setup()
 	if not self:AreDependenciesInstalled() then
 		table.insert( self._errors, "blt_mod_missing_dependencies" )
 		self:RetrieveDependencies()
+		self:SetEnabled( false, true )
 		return
 	end
 


### PR DESCRIPTION
Say that:
- mod A depends on mod B;
- mod B depends on mod C.

If mod C is disabled or not present, mod B is not loaded.
But mod A is loaded and that's a problem.

This patch makes sure the whole chain is not loaded.